### PR TITLE
Add cron job to keep instance alive

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -6,11 +6,6 @@ threadsafe: true
 
 default_expiration: "5d"
 
-cron:
-- description: keep instance alive
-  url: /
-  schedule: every 2 minutes
-
 builtins:
 - appstats: on
 - admin_redirect: on

--- a/app.yaml
+++ b/app.yaml
@@ -6,6 +6,11 @@ threadsafe: true
 
 default_expiration: "5d"
 
+cron:
+- description: keep instance alive
+  url: /
+  schedule: every 2 minutes
+
 builtins:
 - appstats: on
 - admin_redirect: on

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,0 +1,4 @@
+cron:
+- description: keep instance alive
+  url: /
+  schedule: every 2 minutes


### PR DESCRIPTION
If site is quiet, Google App Engine will close the instance, creating an initial latency to the user in the range of seconds. This pings the server every 2 minutes to prevent this.
